### PR TITLE
Use compile_error in macros

### DIFF
--- a/packages/std/macros/src/attrs/mod.rs
+++ b/packages/std/macros/src/attrs/mod.rs
@@ -47,6 +47,11 @@ pub fn derive_execute_attrs(input: TokenStream) -> TokenStream {
 
             TokenStream::from(expanded)
         }
-        _ => panic!("Attrs can only be derived for enums"),
+        _ => {
+            return quote! {
+                compile_error!("Attrs can only be derived for enums");
+            }
+            .into();
+        }
     }
 }

--- a/packages/std/macros/src/execute.rs
+++ b/packages/std/macros/src/execute.rs
@@ -55,7 +55,11 @@ fn andr_exec_derive(input: DeriveInput) -> proc_macro2::TokenStream {
                 #input
             }
         }
-        _ => panic!("unions are not supported"),
+        _ => {
+            return parse_quote! {
+                compile_error!("unions are not supported");
+            };
+        }
     }
 }
 

--- a/packages/std/macros/src/instantiate.rs
+++ b/packages/std/macros/src/instantiate.rs
@@ -24,6 +24,11 @@ pub(crate) fn enum_implementation(_args: TokenStream, input: TokenStream) -> Tok
             }
             .into()
         }
-        _ => panic!("Macro only works with structs"),
+        _ => {
+            return quote! {
+                compile_error!("Macro only works with structs");
+            }
+            .into();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure macro misuse fails at compile time

## Testing
- `cargo check -p andromeda-macros` *(fails: failed to get `cw721` as a dependency)*