### PR TITLE
Refactor Milliseconds overflow handling

### DIFF
--- a/contracts/math/andromeda-time-gate/src/contract.rs
+++ b/contracts/math/andromeda-time-gate/src/contract.rs
@@ -218,7 +218,7 @@ pub fn get_current_ado_path(deps: Deps, env: Env) -> Result<Addr, ContractError>
     );
 
     let current_time_nanos = env.block.time.nanos();
-    let cycle_start_nanos = cycle_start_time_milliseconds.nanos();
+    let cycle_start_nanos = cycle_start_time_milliseconds.nanos()?;
 
     let time_interval_nanos = match time_interval.checked_mul(1_000_000_000) {
         Some(val) => val,

--- a/packages/std/src/common/expiration.rs
+++ b/packages/std/src/common/expiration.rs
@@ -82,7 +82,7 @@ pub fn expiration_from_milliseconds(time: Milliseconds) -> Result<Expiration, Co
         ContractError::InvalidExpirationTime {}
     );
 
-    Ok(Expiration::AtTime(Timestamp::from_nanos(time.nanos())))
+    Ok(Expiration::AtTime(Timestamp::from_nanos(time.nanos()?)))
 }
 
 pub fn block_to_expiration(block: &BlockInfo, model: Expiration) -> Option<Expiration> {


### PR DESCRIPTION
## Summary
- return `Result` from Milliseconds conversion helpers
- propagate possible errors in expiration utilities
- update time-gate to use the new `nanos()` API

## Testing
- `cargo check --locked` *(fails: could not fetch `cw721`)*