### PR TITLE
Fix with_msg result handling

### DIFF
--- a/packages/std/src/amp/recipient.rs
+++ b/packages/std/src/amp/recipient.rs
@@ -145,10 +145,10 @@ impl Recipient {
     }
 
     /// Adds a message to the recipient to be sent alongside any funds
-    pub fn with_msg(self, msg: impl Serialize) -> Self {
+    pub fn with_msg(self, msg: impl Serialize) -> Result<Self, ContractError> {
         let mut new_recip = self;
-        new_recip.msg = Some(to_json_binary(&msg).unwrap());
-        new_recip
+        new_recip.msg = Some(to_json_binary(&msg)?);
+        Ok(new_recip)
     }
 }
 

--- a/tests/auction_app.rs
+++ b/tests/auction_app.rs
@@ -382,7 +382,11 @@ fn test_auction_app_recipient() {
         None,
         None,
         None,
-        Some(Recipient::from_string("./splitter").with_msg(mock_splitter_send_msg(None))),
+        Some(
+            Recipient::from_string("./splitter")
+                .with_msg(mock_splitter_send_msg(None))
+                .unwrap(),
+        ),
     );
     cw721
         .execute_send_nft(

--- a/tests/marketplace_app.rs
+++ b/tests/marketplace_app.rs
@@ -397,7 +397,8 @@ fn test_marketplace_app_recipient() {
                 None,
                 Some(
                     Recipient::from_string(format!("./{}", splitter_component.name))
-                        .with_msg(mock_splitter_send_msg(None)),
+                        .with_msg(mock_splitter_send_msg(None))
+                        .unwrap(),
                 ),
             ),
         )


### PR DESCRIPTION
## Summary
- return `Result<Self, ContractError>` from `Recipient::with_msg`
- unwrap at call sites in tests

## Testing
- `cargo check` *(fails: failed to get `cw721` as a dependency)*