### PR TITLE
Fix missing packet error handling

### DIFF
--- a/contracts/os/andromeda-kernel/src/execute.rs
+++ b/contracts/os/andromeda-kernel/src/execute.rs
@@ -248,8 +248,8 @@ pub fn trigger_relay(
         ContractError::Unauthorized {}
     );
     let ics20_packet_info = CHANNEL_TO_EXECUTE_MSG
-        .load(ctx.deps.storage, (channel_id.clone(), packet_sequence))
-        .expect("No packet found for channel_id and sequence");
+        .may_load(ctx.deps.storage, (channel_id.clone(), packet_sequence))?
+        .ok_or(ContractError::ProcessNotFound {})?;
 
     let chain = ics20_packet_info
         .recipient


### PR DESCRIPTION
## Summary
- return a ContractError when relay packets are missing instead of panicking

## Testing
- `cargo check --locked --offline` *(fails: failed to get `cw721` as a dependency in offline mode)*