### PR TITLE
Fix checked_div zero rate handling

### DIFF
--- a/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
+++ b/contracts/fungible-tokens/andromeda-cw20-exchange/src/contract.rs
@@ -243,7 +243,9 @@ pub fn execute_purchase(
         );
     }
 
-    let purchased = amount_sent.checked_div(sale.exchange_rate).unwrap();
+    let purchased = amount_sent
+        .checked_div(sale.exchange_rate)
+        .ok_or(ContractError::InvalidRate {})?;
     let remainder = amount_sent.checked_sub(purchased.checked_mul(sale.exchange_rate)?)?;
 
     ensure!(


### PR DESCRIPTION
## Summary
- fix `execute_purchase` division by zero

## Testing
- `cargo test --workspace --locked` *(fails: failed to fetch git dependency `cw721`)*