### PR TITLE
Return error for missing ICS20 channel in kernel

### DIFF
--- a/contracts/os/andromeda-kernel/src/ibc.rs
+++ b/contracts/os/andromeda-kernel/src/ibc.rs
@@ -221,9 +221,11 @@ pub fn do_ibc_packet_receive(
             let res = execute::send(execute_env, msg)?;
 
             // Refunds must be done via the ICS20 channel
-            let ics20_channel_id = channel_info
-                .ics20_channel_id
-                .expect("Cannot refund, ICS20 Channel ID not set");
+            let ics20_channel_id = channel_info.ics20_channel_id.ok_or(
+                ContractError::InvalidPacket {
+                    error: Some(format!("ICS20 channel not found for chain {chain}")),
+                },
+            )?;
             // Save refund info
             REFUND_DATA.save(
                 deps.storage,


### PR DESCRIPTION
## Summary
- handle missing ICS20 channel in `do_ibc_packet_receive`

## Testing
- `cargo unit-test --workspace --locked --offline` *(fails: could not fetch git dependency)*
- `cargo test -p tests --locked --quiet` *(fails: could not fetch git dependency)*