### PR TITLE
Fix cw721 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ cw20 = "2.0.0"
 cw20-base = "2.0.0"
 cw3 = "2.0.0"
 cw4 = "2.0.0"
-cw721 = { git = "https://github.com/andromedaprotocol/cw721-2.2", branch = "removeExtension" }
-cw721-base = { git = "https://github.com/andromedaprotocol/cw721-2.2", branch = "removeExtension" }
+cw721 = "0.20.0"
+cw721-base = "0.20.0"
 cw-asset = "4.0.0"
 cosmwasm-schema = "^2.2"
 semver = "1.0.25"


### PR DESCRIPTION
## Summary
- use crates.io `cw721` & `cw721-base`

## Testing
- `cargo generate-lockfile` *(fails: could not connect to server)*