### PR TITLE
Fix serde dev deps and unify serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ cosmwasm-schema = "^2.2"
 semver = "1.0.25"
 enum-repr = "0.2.6"
 cw-multi-test = "2.4.0"
-serde = { version = "1.0.217" }
+serde = { version = "1.0.219", features = ["derive"] }
 test-case = { version = "3.3.1" }
 cw-orch = "0.27.0"
 cw-orch-daemon = "0.29.1"

--- a/packages/andromeda-cw-json/Cargo.toml
+++ b/packages/andromeda-cw-json/Cargo.toml
@@ -12,10 +12,7 @@ keywords = ["serde", "wasm", "json"]
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-serde = { workspace = true, default-features = false, features = ["derive"] }
+serde = { workspace = true }
 serde-cw-value = { version = "^0.7.0" }
 thiserror = { version = "2.0.12", default-features = false }
 
-
-[dev-dependencies]
-serde_derive = "^1.0.210"

--- a/packages/deploy/Cargo.toml
+++ b/packages/deploy/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
-serde = { version = "1.0.219", default-features = false, features = ["derive"] }
+serde = { workspace = true }
 cw-orch = { workspace = true }
 cw-orch-daemon = "0.29.1"
 thiserror = "2.0.12"
@@ -19,7 +19,7 @@ env_logger = "0.11.8"
 log = "0.4"
 dotenv = "0.15.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-serde_json = "1.0"
+serde_json = { workspace = true }
 chrono = "0.4"
 
 # OS Contracts
@@ -79,16 +79,3 @@ andromeda-std = { workspace = true }
 [dev-dependencies]
 cw-multi-test = { workspace = true }
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
-
-[build]
-incremental = true


### PR DESCRIPTION
## Summary
- remove unused serde_derive from `andromeda-cw-json`
- use workspace version of serde_json in deploy crate

## Testing
- `cargo check --workspace` *(fails: failed to download from `https://index.crates.io/config.json`)*