### PR TITLE
Implement fractional NFT ADO

### DIFF
--- a/contracts/non-fungible-tokens/andromeda-fractional-nft/Cargo.toml
+++ b/contracts/non-fungible-tokens/andromeda-fractional-nft/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "andromeda-fractional-nft"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+library = []
+testing = ["cw-multi-test", "andromeda-testing"]
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw-utils = { workspace = true }
+cw20 = { workspace = true }
+cw20-base = { workspace = true }
+cw721 = { workspace = true }
+cw721-base = { workspace = true }
+andromeda-std = { workspace = true, features = ["rates"] }
+andromeda-non-fungible-tokens = { workspace = true }
+andromeda-fungible-tokens = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cw-multi-test = { workspace = true, optional = true }
+andromeda-testing = { workspace = true, optional = true }
+cw-orch = { workspace = true }
+
+[dev-dependencies]
+andromeda-app = { workspace = true }

--- a/contracts/non-fungible-tokens/andromeda-fractional-nft/README.md
+++ b/contracts/non-fungible-tokens/andromeda-fractional-nft/README.md
@@ -1,0 +1,30 @@
+# Overview
+
+The Fractional NFT ADO allows a single NFT to be split into a user-defined number of fungible tokens. It deploys a CW721 contract representing the underlying asset and a CW20 contract that represents ownership shares.
+
+## InstantiateMsg
+- `kernel_address`: Address of the Andromeda kernel contract.
+- `owner`: Optional owner of the ADO.
+
+## ExecuteMsg
+### `CreateFractionalizedAsset`
+Deploys both the CW721 and CW20 contracts.
+- `asset`: `AssetParams`
+  - `cw721_code_id`: Code ID for the CW721 contract
+  - `name`: NFT collection name
+  - `symbol`: NFT collection symbol
+  - `token_uri`: Optional metadata URI for the token
+  - `token_id`: Token ID to mint in the newly created CW721 contract
+- `fractions`: `FractionalParams`
+  - `cw20_code_id`: Code ID for the CW20 contract
+  - `supply`: Total supply of fractional tokens
+  - `name`: Token name
+  - `symbol`: Token symbol
+  - `decimals`: CW20 decimals
+
+Executing this message returns a response containing two `WasmMsg::Instantiate` messages for the CW721 and CW20 contracts. The caller receives the full supply of the newly created fractional tokens.
+
+## Testing
+
+Run `cargo test --workspace` to execute the unit tests. The provided test ensures that the contract produces the expected instantiate messages when creating a fractionalized asset.
+

--- a/contracts/non-fungible-tokens/andromeda-fractional-nft/src/contract.rs
+++ b/contracts/non-fungible-tokens/andromeda-fractional-nft/src/contract.rs
@@ -1,0 +1,137 @@
+use andromeda_fungible_tokens::cw20::InstantiateMsg as Cw20InstantiateMsg;
+use andromeda_non_fungible_tokens::cw721::InstantiateMsg as Cw721InstantiateMsg;
+use andromeda_std::{
+    ado_base::{InstantiateMsg as BaseInstantiateMsg, MigrateMsg},
+    ado_contract::ADOContract,
+    amp::AndrAddr,
+    andr_execute_fn,
+    common::context::ExecuteContext,
+    error::ContractError,
+};
+use cosmwasm_std::{
+    entry_point, to_json_binary, DepsMut, Env, MessageInfo, Response, Uint128, WasmMsg,
+};
+use cw20::Cw20Coin;
+use cosmwasm_schema::cw_serde;
+
+const CONTRACT_NAME: &str = "crates.io:andromeda-fractional-nft";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub kernel_address: String,
+    pub owner: Option<String>,
+}
+
+#[cw_serde]
+pub struct FractionalParams {
+    pub cw20_code_id: u64,
+    pub supply: u128,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+#[cw_serde]
+pub struct AssetParams {
+    pub cw721_code_id: u64,
+    pub name: String,
+    pub symbol: String,
+    pub token_uri: Option<String>,
+    pub token_id: String,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    CreateFractionalizedAsset {
+        asset: AssetParams,
+        fractions: FractionalParams,
+    },
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let contract = ADOContract::default();
+    let resp = contract.instantiate(
+        deps.storage,
+        env,
+        deps.api,
+        &deps.querier,
+        info,
+        BaseInstantiateMsg {
+            ado_type: CONTRACT_NAME.to_string(),
+            ado_version: CONTRACT_VERSION.to_string(),
+            kernel_address: msg.kernel_address,
+            owner: msg.owner,
+        },
+    )?;
+
+    Ok(resp)
+}
+
+#[andr_execute_fn]
+pub fn execute(ctx: ExecuteContext, msg: ExecuteMsg) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::CreateFractionalizedAsset { asset, fractions } => {
+            execute_create_fractionalized_asset(ctx, asset, fractions)
+        }
+    }
+}
+
+fn execute_create_fractionalized_asset(
+    mut ctx: ExecuteContext,
+    asset: AssetParams,
+    fractions: FractionalParams,
+) -> Result<Response, ContractError> {
+    let ExecuteContext { deps, env, info, .. } = &mut ctx;
+
+    let kernel_address = ADOContract::default().get_kernel_address(deps.storage)?;
+
+    let cw721_msg = Cw721InstantiateMsg {
+        name: asset.name,
+        symbol: asset.symbol,
+        minter: AndrAddr::from_string(env.contract.address.to_string()),
+        kernel_address: kernel_address.to_string(),
+        owner: Some(info.sender.to_string()),
+    };
+
+    let cw20_msg = Cw20InstantiateMsg {
+        name: fractions.name,
+        symbol: fractions.symbol,
+        decimals: fractions.decimals,
+        initial_balances: vec![Cw20Coin {
+            address: info.sender.to_string(),
+            amount: Uint128::from(fractions.supply),
+        }],
+        mint: None,
+        marketing: None,
+        kernel_address: kernel_address.to_string(),
+        owner: Some(info.sender.to_string()),
+    };
+
+    let cw721_inst = WasmMsg::Instantiate {
+        admin: Some(info.sender.to_string()),
+        code_id: asset.cw721_code_id,
+        msg: to_json_binary(&cw721_msg)?,
+        funds: vec![],
+        label: "fractional-nft".to_string(),
+    };
+
+    let cw20_inst = WasmMsg::Instantiate {
+        admin: Some(info.sender.to_string()),
+        code_id: fractions.cw20_code_id,
+        msg: to_json_binary(&cw20_msg)?,
+        funds: vec![],
+        label: "fractional-cw20".to_string(),
+    };
+
+    Ok(Response::new()
+        .add_message(cw721_inst)
+        .add_message(cw20_inst)
+        .add_attribute("action", "create_fractionalized_asset"))
+}

--- a/contracts/non-fungible-tokens/andromeda-fractional-nft/src/interface.rs
+++ b/contracts/non-fungible-tokens/andromeda-fractional-nft/src/interface.rs
@@ -1,0 +1,35 @@
+use super::contract::{execute, instantiate, ExecuteMsg, InstantiateMsg};
+use cw_orch::prelude::*;
+
+pub struct FractionalNftContract(pub cw_orch::daemon::daemon::UncheckedContract);
+
+impl<Chain: CwEnv> Deployable<Chain> for FractionalNftContract {
+    fn from_code_id(code_id: u64, chain: Chain) -> Self {
+        FractionalNftContract(UncheckedContract::from_id(code_id, chain))
+    }
+
+    fn wrapper(&self) -> &UncheckedContract {
+        &self.0
+    }
+}
+
+impl<Chain: CwEnv> Uploadable<Chain> for FractionalNftContract {}
+
+impl<Chain: CwEnv> Instantiateable<Chain> for FractionalNftContract {
+    type InstantiateMsg = InstantiateMsg;
+
+    fn instantiate(&self, chain: Chain, msg: Self::InstantiateMsg) -> anyhow::Result<Contract<Chain>> {
+        self.0.instantiate(&chain, msg, None, "fractional-nft", None)
+    }
+}
+
+impl<Chain: CwEnv> Executable<Chain> for FractionalNftContract {
+    type ExecuteMsg = ExecuteMsg;
+
+    fn execute<Msg>(&self, chain: Chain, msg: Msg) -> anyhow::Result<<Chain as CwEnv>::Response>
+    where
+        Msg: Into<Self::ExecuteMsg>,
+    {
+        self.0.execute(&chain, msg, None)
+    }
+}

--- a/contracts/non-fungible-tokens/andromeda-fractional-nft/src/lib.rs
+++ b/contracts/non-fungible-tokens/andromeda-fractional-nft/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod contract;
+#[cfg(test)]
+mod testing;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod interface;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::interface::FractionalNftContract;

--- a/contracts/non-fungible-tokens/andromeda-fractional-nft/src/testing.rs
+++ b/contracts/non-fungible-tokens/andromeda-fractional-nft/src/testing.rs
@@ -1,0 +1,68 @@
+#[cfg(test)]
+mod tests {
+    use super::super::contract::{
+        execute, instantiate, AssetParams, ExecuteMsg, FractionalParams, InstantiateMsg,
+    };
+    use andromeda_std::common::context::ExecuteContext;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::{attr, CosmosMsg, WasmMsg};
+
+    #[test]
+    fn test_instantiate() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("creator", &[]);
+        let msg = InstantiateMsg { kernel_address: "kernel".into(), owner: None };
+        instantiate(deps.as_mut(), env, info, msg).unwrap();
+    }
+
+    #[test]
+    fn test_execute_create_fractionalized_asset() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info("creator", &[]);
+
+        let instantiate_msg = InstantiateMsg { kernel_address: "kernel".into(), owner: None };
+        instantiate(deps.as_mut(), env.clone(), info.clone(), instantiate_msg).unwrap();
+
+        let exec_msg = ExecuteMsg::CreateFractionalizedAsset {
+            asset: AssetParams {
+                cw721_code_id: 1,
+                name: "Asset".into(),
+                symbol: "AST".into(),
+                token_uri: None,
+                token_id: "1".into(),
+            },
+            fractions: FractionalParams {
+                cw20_code_id: 2,
+                supply: 1000,
+                name: "Fraction".into(),
+                symbol: "FRAC".into(),
+                decimals: 6,
+            },
+        };
+
+        let ctx = ExecuteContext {
+            deps: deps.as_mut(),
+            env,
+            info,
+            querier: &deps.querier,
+        };
+        let res = execute(ctx, exec_msg).unwrap();
+
+        assert_eq!(res.attributes, vec![attr("action", "create_fractionalized_asset")]);
+        assert_eq!(res.messages.len(), 2);
+
+        if let CosmosMsg::Wasm(WasmMsg::Instantiate { code_id, .. }) = &res.messages[0].msg {
+            assert_eq!(*code_id, 1);
+        } else {
+            panic!("expected WasmMsg::Instantiate for cw721");
+        }
+
+        if let CosmosMsg::Wasm(WasmMsg::Instantiate { code_id, .. }) = &res.messages[1].msg {
+            assert_eq!(*code_id, 2);
+        } else {
+            panic!("expected WasmMsg::Instantiate for cw20");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add functional logic to fractional NFT contract
- add tests verifying CW721 and CW20 instantiation
- document new ADO in README

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo clippy --workspace -- -D warnings` *(fails: clippy not installed)*
- `cargo test --workspace` *(fails to download dependencies due to network issues)*